### PR TITLE
 chore(docs): add deploy guide for Next.js on vercel in docs/deploy

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,4 +5,3 @@ dist
 # files
 package-lock.json
 pnpm-lock.yaml
-*.mdx

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
           "*.json",
           "*.yml",
           "*.yaml",
-          "*.md"
+          "*.md",
+          "*.mdx"
         ],
         "options": {
           "tabWidth": 2

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:vercel": "rm -rf .next && vercel build",
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix",

--- a/src/app/docs/deploy/page.mdx
+++ b/src/app/docs/deploy/page.mdx
@@ -1,0 +1,48 @@
+import { Code } from "@/ui/code"
+
+# Deploy
+
+In this document, you will learn how to deploy your JavaScript-based web application using Vercel CLI or GitHub Actions.
+
+## Using the Vercel CLI
+
+Vercel provides a CLI that helps us deploy the application using the terminal with a simple series of steps. Don't worry about the length or complexity of the files.
+
+### Install Vercel as a global dependency
+
+Use the following command to install Vercel globally using npm or pnpm package managers:
+
+<Code
+    lang="bash"
+    code={`
+npm i -g vercel@latest
+# or
+pnpm add -g vercel@latest   
+    `}
+/>
+
+### Link Your Project
+
+Link your local project with your remote projects on Vercel that exist in your account. Follow these steps to link the project:
+
+<Code
+    lang="bash"
+    code={`
+vercel link
+ ? Set up "~\path" ?
+ ? Which scope should contain your project ?
+ ? Link to existing project ?
+ ? What's your project's name ?
+  `}
+/>
+
+### Build Your Project
+
+Build your local project. Follow the next step:
+
+<Code
+    lang="bash"
+    code={`
+vercel build
+    `}
+/>

--- a/src/app/docs/deploy/page.mdx
+++ b/src/app/docs/deploy/page.mdx
@@ -1,28 +1,120 @@
 import { Code } from "@/ui/code"
 import { deploy } from "@/lib/code"
+import { Mark } from "@/ui/mark"
 
 # Deploy
 
-In this document, you will learn how to deploy your JavaScript-based web application using Vercel CLI or GitHub Actions.
+In this document, you will learn how to deploy your JavaScript-based web application using the Vercel CLI or
+GitHub Actions.
 
 ## Using the Vercel CLI
 
-Vercel provides a CLI that helps us deploy the application using the terminal with a simple series of steps. Don't worry about the length or complexity of the files.
+Vercel provides a CLI that helps us deploy the application using the terminal with a simple series of steps.
+Don't worry about the length or complexity of the files.
 
 ### Install Vercel as a global dependency
 
 Use the following command to install Vercel globally using npm or pnpm package managers:
 
-<Code lang="bash" code={deploy.installation} />
+{/* prettier-ignore */}
+<Code lang="bash">
+\# npm
+npm install -g vercel@latest
+\# pnpm
+pnpm install -g vercel@latest
+</Code>
+
+### Login
+
+Log in to your Vercel account using either Google, GitHub, or Email.
+
+<Code lang="bash">vercel login</Code>
 
 ### Link Your Project
 
-Link your local project with your remote projects on Vercel that exist in your account. Follow these steps to link the project:
+Link your local project with your remote projects on Vercel that exist in your account. Follow these steps
+to link the project:
 
-<Code lang="bash" code={deploy.link} />
+{/* prettier-ignore */}
+<Code lang="bash">
+vercel link
+ ? Set up "~\path" ?
+ ? Which scope should contain your project ?
+ ? Link to existing project ?
+ ? What's your project's name ?
+</Code>
+
+### Pull Configuration From Vercel Online
+
+It is recommended to run the <Mark>vercel pull</Mark> command before the <Mark>vercel build</Mark> command
+to retrieve the environment variables from the remote project.
 
 ### Build Your Project
 
 Build your local project. Follow the next step:
 
-<Code lang="bash" code={deploy.build} />
+<Code lang="bash">vercel build --target=production</Code>
+
+This command builds your project locally or in your CI environment. The build artifacts are placed by default
+into the <Mark>./vercel/output</Mark> directory. You can see the files generated in the build process
+and check if they were created correctly. If there are any errors or issues, you can fix them and re-run the command.
+
+You can also specify different environments using the <Mark>--target</Mark> flag, such as:
+
+{/* prettier-ignore */}
+<Code lang="bash">
+vercel build --target=production 
+\# or 
+vercel build --target=staging
+</Code>
+
+### Unstable
+
+Although the Vercel CLI is powerful and simple, it is not yet fully stable. In multiple operations and processes,
+it may not work as expected or return unexpected values. However, it is a great tool that can enhance productivity
+over time.
+
+## GitHub Actions
+
+Using Vercel with GitHub Actions is a powerful and advanced use case for automating processes like
+
+<Mark>Preview Deployments</Mark>, <Mark>Development Deployments</Mark>, and <Mark>Production Deployments</Mark>. These actions are
+triggered by events in your repository, such as push, pull_request, or release.
+
+This approach allows you to customize and have better control over the CI/CD pipeline of your project. If you want
+a basic and controlled access to the resources to be deployed, use <Mark>vercel build</Mark>.
+
+### Preview Deployment
+
+A <Mark>Preview Deployment</Mark> is created every time users push a commit to a remote branch. This deployment is
+useful for checking the state of the changes made in the commit, such as the latest UI changes or verifying if the
+build process was successful.
+
+<Code lang="bash" children={deploy.preview} />
+
+### Production Deployment
+
+A <Mark>Production Deployment</Mark> is created when a commit is made to the main branch (by default, master or main).
+This environment is frequently used after merging a pull request.
+
+<Code lang="bash" children={deploy.production} />
+
+### Setup Workflows
+
+To deploy the application to any environment you have set up for the project using the CLI or the online project
+configuration, you need to configure the <Mark>VERCEL_ORG_ID</Mark> and <Mark>VERCEL_PROJECT_ID</Mark> variables.
+Follow these steps to obtain and use them:
+
+1. Generate the [Access Token](https://vercel.com/guides/how-do-i-use-a-vercel-api-access-token).
+2. Install the [Vercel CLI](https://vercel.com/docs/cli).
+3. Log in to your Vercel account by running <Mark>vercel login</Mark>.
+4. Link your project by running <Mark>vercel link</Mark>.
+5. Pull environment variables from the remote project by running <Mark>vercel pull</Mark>.
+6. Inside the generated <Mark>.vercel</Mark> folder, locate the <Mark>project.json</Mark> file, which contains the
+   <Mark>projectId</Mark> and <Mark>orgId</Mark> fields.
+7. Go to your GitHub repository and open the <Mark>Settings</Mark>.
+8. Navigate to <Mark>Secrets and variables</Mark> and click on <Mark>Actions</Mark>.
+9. Create three <Mark>Repository secrets</Mark> named:
+   - <Mark>VERCEL_TOKEN</Mark>
+   - <Mark>VERCEL_ORG_ID</Mark>
+   - <Mark>VERCEL_PROJECT_ID</Mark>

--- a/src/app/docs/deploy/page.mdx
+++ b/src/app/docs/deploy/page.mdx
@@ -63,8 +63,8 @@ You can also specify different environments using the <Mark>--target</Mark> flag
 
 {/* prettier-ignore */}
 <Code lang="bash">
-vercel build --target=production 
-\# or 
+vercel build --target=production
+\# or
 vercel build --target=staging
 </Code>
 

--- a/src/app/docs/deploy/page.mdx
+++ b/src/app/docs/deploy/page.mdx
@@ -1,4 +1,5 @@
 import { Code } from "@/ui/code"
+import { deploy } from "@/lib/code"
 
 # Deploy
 
@@ -12,37 +13,16 @@ Vercel provides a CLI that helps us deploy the application using the terminal wi
 
 Use the following command to install Vercel globally using npm or pnpm package managers:
 
-<Code
-    lang="bash"
-    code={`
-npm i -g vercel@latest
-# or
-pnpm add -g vercel@latest   
-    `}
-/>
+<Code lang="bash" code={deploy.installation} />
 
 ### Link Your Project
 
 Link your local project with your remote projects on Vercel that exist in your account. Follow these steps to link the project:
 
-<Code
-    lang="bash"
-    code={`
-vercel link
- ? Set up "~\path" ?
- ? Which scope should contain your project ?
- ? Link to existing project ?
- ? What's your project's name ?
-  `}
-/>
+<Code lang="bash" code={deploy.link} />
 
 ### Build Your Project
 
 Build your local project. Follow the next step:
 
-<Code
-    lang="bash"
-    code={`
-vercel build
-    `}
-/>
+<Code lang="bash" code={deploy.build} />

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -3,4 +3,5 @@ import { LayoutProps } from "@/lib/@types/props"
 const DocsLayout = ({ children }: LayoutProps) => {
     return <main className="w-10/12 mt-8 mb-20 mx-auto text-gray">{children}</main>
 }
+
 export default DocsLayout

--- a/src/app/docs/mdx/page.mdx
+++ b/src/app/docs/mdx/page.mdx
@@ -10,7 +10,12 @@ about structural content or components.
 
 ## Installation
 
-<Code lang="bash" code={mdx.installation} />
+{/* prettier-ignore */}
+<Code lang="bash">
+npm install @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
+\# or
+pnpm add @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
+</Code>
 
 ## Configuration
 
@@ -18,8 +23,9 @@ To ensure compatibility with MDX, follow these steps to enable the necessary ext
 
 ### Setup `next.config.ts` file
 
-<Code lang="ts" code={mdx.nextConfig} />
+{/* prettier-ignore */}
+<Code lang="ts" children={mdx.nextConfig} />
 
 ### Add `mdx-components.tsx` file
 
-<Code lang="tsx" code={mdx.mdxComponents} />
+<Code lang="tsx" children={mdx.mdxComponents} />

--- a/src/app/docs/mdx/page.mdx
+++ b/src/app/docs/mdx/page.mdx
@@ -1,4 +1,5 @@
 import { Code } from "@/ui/code"
+import { mdx } from "@/lib/code"
 
 # Next.js MDX
 
@@ -12,9 +13,9 @@ about structural content or components.
 <Code
     lang="bash"
     code={`
-npm install @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
-# or
-pnpm add @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
+  npm install @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
+  # or
+  pnpm add @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
 `}
 />
 
@@ -24,33 +25,8 @@ To ensure compatibility with MDX, follow these steps to enable the necessary ext
 
 ### Setup `next.config.ts` file
 
-<Code
-  lang="ts"
-  code={`
-  import type { NextConfig } from "next"
-  import createMDX from "@next/mdx"
-
-  const nextConfig: NextConfig = {
-    pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdx"],
-  } 
-
-  const withMDX = createMDX({
-    options: {},
-  })
-
-  export default withMDX(nextConfig)
-  `}
-/>
+<Code lang="ts" code={mdx.nextConfig} />
 
 ### Add `mdx-components.tsx` file
 
-<Code 
-  lang="ts"
-  code={`
-  import type { MDXComponents } from "mdx/types"
-
-  export function useMDXComponents(components: MDXComponents): MDXComponents {
-    return { ...components }
-  }
-  `}
-/>
+<Code lang="tsx" code={mdx.mdxComponents} />

--- a/src/app/docs/mdx/page.mdx
+++ b/src/app/docs/mdx/page.mdx
@@ -10,14 +10,7 @@ about structural content or components.
 
 ## Installation
 
-<Code
-    lang="bash"
-    code={`
-  npm install @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
-  # or
-  pnpm add @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
-`}
-/>
+<Code lang="bash" code={mdx.installation} />
 
 ## Configuration
 

--- a/src/lib/@types/props.ts
+++ b/src/lib/@types/props.ts
@@ -5,7 +5,7 @@ export interface LayoutProps {
 }
 
 export interface CodeProps {
-    code: string
+    children?: string
     lang?: BundledLanguage
     fileName?: string
 }

--- a/src/lib/code.ts
+++ b/src/lib/code.ts
@@ -1,9 +1,4 @@
 export const mdx = {
-    installation: `
-npm install @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
-# or
-pnpm add @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
-    `,
     nextConfig: `
 import type { NextConfig } from "next"
 import createMDX from "@next/mdx"
@@ -28,19 +23,51 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
 }
 
 export const deploy = {
-    installation: `
-npm i -g vercel@latest
-# or
-pnpm add -g vercel@latest
-    `,
-    link: `
-vercel link
- ? Set up "~\path" ?
- ? Which scope should contain your project ?
- ? Link to existing project ?
- ? What's your project's name ?
-    `,
-    build: `
-vercel build
+    preview: `
+name: Vercel Preview Deployment
+env:
+  VERCEL_ORG_ID: \${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: \${{ secrets.VERCEL_PROJECT_ID }}
+on:
+  push:
+    branches-ignore:
+      - main
+jobs:
+  Deploy-Preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=\${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --token=\${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --token=\${{ secrets.VERCEL_TOKEN }}
+  `,
+    production: `
+name: Vercel Production Deployment
+env:
+  VERCEL_ORG_ID: \${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: \${{ secrets.VERCEL_PROJECT_ID }}
+on:
+  push:
+    branches:
+      - main
+jobs:
+  Deploy-Production:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=\${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=\${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=\${{ secrets.VERCEL_TOKEN }}
+
     `,
 }

--- a/src/lib/code.ts
+++ b/src/lib/code.ts
@@ -1,4 +1,9 @@
 export const mdx = {
+    installation: `
+npm install @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
+# or
+pnpm add @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
+    `,
     nextConfig: `
 import type { NextConfig } from "next"
 import createMDX from "@next/mdx"
@@ -12,12 +17,30 @@ const withMDX = createMDX({
 })
 
 export default withMDX(nextConfig)
-`,
+    `,
     mdxComponents: `
 import type { MDXComponents } from "mdx/types"
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return { ...components }
 }
-`,
+    `,
+}
+
+export const deploy = {
+    installation: `
+npm i -g vercel@latest
+# or
+pnpm add -g vercel@latest
+    `,
+    link: `
+vercel link
+ ? Set up "~\path" ?
+ ? Which scope should contain your project ?
+ ? Link to existing project ?
+ ? What's your project's name ?
+    `,
+    build: `
+vercel build
+    `,
 }

--- a/src/lib/code.ts
+++ b/src/lib/code.ts
@@ -1,0 +1,23 @@
+export const mdx = {
+    nextConfig: `
+import type { NextConfig } from "next"
+import createMDX from "@next/mdx"
+
+const nextConfig: NextConfig = {
+  pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdx"],
+}
+
+const withMDX = createMDX({
+  options: {},
+})
+
+export default withMDX(nextConfig)
+`,
+    mdxComponents: `
+import type { MDXComponents } from "mdx/types"
+
+export function useMDXComponents(components: MDXComponents): MDXComponents {
+  return { ...components }
+}
+`,
+}

--- a/src/ui/code.tsx
+++ b/src/ui/code.tsx
@@ -1,3 +1,4 @@
+import { Children } from "react"
 import { createCssVariablesTheme, createHighlighter } from "shiki"
 import { CodeProps } from "@/lib/@types/props"
 
@@ -12,14 +13,18 @@ const createTheme = await createHighlighter({
     themes: [cssVariables],
 })
 
-export const Code = async ({ code, lang = "ts" }: CodeProps) => {
-    const html = createTheme.codeToHtml(code.trim(), {
-        lang,
-        theme: "css-variables",
+export const Code = async ({ children = "", lang = "ts" }: CodeProps) => {
+    return Children.map(children, async (child) => {
+        // @ts-ignore
+        const convertToString = typeof child === "string" ? child.trim() : child?.props?.children?.trim()
+        const html = createTheme.codeToHtml(convertToString, {
+            lang,
+            theme: "css-variables",
+        })
+        return (
+            <div className="my-4 overflow-x-hidden">
+                <div dangerouslySetInnerHTML={{ __html: html }} />
+            </div>
+        )
     })
-    return (
-        <div className="overflow-x-hidden">
-            <div dangerouslySetInnerHTML={{ __html: html }} />
-        </div>
-    )
 }

--- a/src/ui/code.tsx
+++ b/src/ui/code.tsx
@@ -15,8 +15,11 @@ const createTheme = await createHighlighter({
 
 export const Code = async ({ children = "", lang = "ts" }: CodeProps) => {
     return Children.map(children, async (child) => {
-        // @ts-ignore
-        const convertToString = typeof child === "string" ? child.trim() : child?.props?.children?.trim()
+        const convertToString =
+            typeof child === "string"
+                ? child.trim()
+                : // @ts-expect-error the children cannot be a string
+                  child?.props?.children?.trim()
         const html = createTheme.codeToHtml(convertToString, {
             lang,
             theme: "css-variables",

--- a/src/ui/globals.css
+++ b/src/ui/globals.css
@@ -7,7 +7,7 @@
     --shiki-foreground: #eeeeee;
     --shiki-background: #0a0a0a;
     --shiki-token-constant: hsl(210, 100%, 66%);
-    --shiki-token-string: hsl(0, 0%, 93%);
+    --shiki-token-string: hsl(131, 43%, 57%);
     --shiki-token-comment: hsl(0, 0%, 63%);
     --shiki-token-keyword: hsl(341, 90%, 67%);
     --shiki-token-parameter: hsl(39, 90%, 50%);
@@ -43,5 +43,25 @@
         pre {
             @apply p-4 rounded overflow-x-auto border-gray-100 scroll:h-2 track:mx-1 thumb:rounded thumb:bg-gray-100;
         }
+
+        p + p {
+            @apply my-4;
+        }
+
+        ol {
+            @apply m-4 mr-0 list-decimal list-inside space-y-1;
+        }
+
+        ul {
+            @apply m-4 mr-0 list-disc list-inside space-y-1;
+        }
+
+        a {
+            @apply text-[#52a8ff];
+        }
+    }
+
+    .mark {
+        @apply mx-1 py-0.5 px-1 tracking-wide text-mark rounded bg-[#0a0a0a];
     }
 }

--- a/src/ui/mark.tsx
+++ b/src/ui/mark.tsx
@@ -1,0 +1,5 @@
+import { LayoutProps } from "@/lib/@types/props"
+
+export const Mark = ({ children }: LayoutProps) => {
+    return <span className="mark">{children}</span>
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,7 @@ export default {
                     200: "#1B1B1B",
                     300: "#161616",
                 },
+                mark: "var(--shiki-token-link)",
             },
         },
     },


### PR DESCRIPTION
## Description
This pull request introduces the deploy page, which includes documentation information on how to deploy your Next.js project using the Vercel CLI.


## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
